### PR TITLE
Add telemetry parsing tool (tools/telemetry-parsing) and README link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,7 @@ SquirrelCast is an Android smartphone-based video-out solution for newer DJI gog
 
 ## Additional Tools
 
-- _Coming soon: A tool to parse telemetry logs._
+- [Telemetry Parsing Tool](tools/telemetry-parsing/index.html)
 
 ## Credits
 

--- a/tools/telemetry-parsing/app.js
+++ b/tools/telemetry-parsing/app.js
@@ -1,0 +1,302 @@
+const fileInput = document.getElementById("csvFile");
+const exportButton = document.getElementById("exportKml");
+const resetButton = document.getElementById("reset");
+const statusEl = document.getElementById("status");
+const statsEl = document.getElementById("stats");
+const tooltip = document.getElementById("tooltip");
+
+const map = L.map("map", { zoomControl: true }).setView([0, 0], 2);
+L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+  attribution: "&copy; OpenStreetMap contributors",
+  maxZoom: 19,
+}).addTo(map);
+
+let polyline = null;
+let hoverMarker = null;
+let points = [];
+
+const columnKeys = {
+  latDeg: "flight.osd.lat_deg",
+  lonDeg: "flight.osd.lon_deg",
+  latRad: "flight.osd.lat_rad",
+  lonRad: "flight.osd.lon_rad",
+  alt: "flight.osd.rel_h_m",
+  altHome: "flight.home.alt_m",
+  batterySoc: "battery.dynamic.soc",
+  batteryMv: "battery.dynamic.voltage_mv",
+  homeLatDeg: "flight.home.lat_deg",
+  homeLonDeg: "flight.home.lon_deg",
+  homeLatRad: "flight.home.lat_rad",
+  homeLonRad: "flight.home.lon_rad",
+  timestamp: "timestamp",
+};
+
+const toDegrees = (radians) => (Number.isFinite(radians) ? (radians * 180) / Math.PI : null);
+
+const formatSoc = (value) => {
+  if (!Number.isFinite(value)) return "—";
+  const percent = value <= 1.1 ? value * 100 : value;
+  return `${percent.toFixed(1)}%`;
+};
+
+const formatVoltage = (value) => {
+  if (!Number.isFinite(value)) return "—";
+  const volts = value > 1000 ? value / 1000 : value;
+  return `${volts.toFixed(2)} V`;
+};
+
+const formatAltitude = (value) => {
+  if (!Number.isFinite(value)) return "—";
+  return `${value.toFixed(1)} m`;
+};
+
+const haversineMeters = (lat1, lon1, lat2, lon2) => {
+  const toRad = (deg) => (deg * Math.PI) / 180;
+  const r = 6371000;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return 2 * r * Math.asin(Math.sqrt(a));
+};
+
+const bearingDegrees = (lat1, lon1, lat2, lon2) => {
+  const toRad = (deg) => (deg * Math.PI) / 180;
+  const toDeg = (rad) => (rad * 180) / Math.PI;
+  const y = Math.sin(toRad(lon2 - lon1)) * Math.cos(toRad(lat2));
+  const x =
+    Math.cos(toRad(lat1)) * Math.sin(toRad(lat2)) -
+    Math.sin(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.cos(toRad(lon2 - lon1));
+  return (toDeg(Math.atan2(y, x)) + 360) % 360;
+};
+
+const resetState = () => {
+  points = [];
+  statusEl.textContent = "No file loaded.";
+  statsEl.textContent = "";
+  exportButton.disabled = true;
+  resetButton.disabled = true;
+  tooltip.hidden = true;
+
+  if (polyline) {
+    map.removeLayer(polyline);
+    polyline = null;
+  }
+  if (hoverMarker) {
+    map.removeLayer(hoverMarker);
+    hoverMarker = null;
+  }
+};
+
+const updateSummary = (meta) => {
+  const details = [
+    `Points: ${meta.points}`,
+    `Time span: ${meta.start} → ${meta.end}`,
+  ];
+  statsEl.textContent = details.join("\n");
+};
+
+const createKml = (trackPoints) => {
+  const coordinates = trackPoints
+    .map((point) => `${point.lon},${point.lat},${point.alt ?? 0}`)
+    .join(" ");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <name>SquirrelCast Telemetry Track</name>
+    <Placemark>
+      <name>Flight Track</name>
+      <Style>
+        <LineStyle>
+          <color>ff00ccff</color>
+          <width>3</width>
+        </LineStyle>
+      </Style>
+      <LineString>
+        <tessellate>1</tessellate>
+        <altitudeMode>absolute</altitudeMode>
+        <coordinates>${coordinates}</coordinates>
+      </LineString>
+    </Placemark>
+  </Document>
+</kml>`;
+};
+
+const downloadKml = () => {
+  if (!points.length) return;
+  const kml = createKml(points);
+  const blob = new Blob([kml], { type: "application/vnd.google-earth.kml+xml" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = "squirrelcast-telemetry.kml";
+  anchor.click();
+  URL.revokeObjectURL(url);
+};
+
+const findNearestPoint = (latlng) => {
+  if (!points.length) return null;
+  const target = map.latLngToLayerPoint(latlng);
+  let closest = null;
+  let minDist = Infinity;
+
+  points.forEach((point) => {
+    const layerPoint = map.latLngToLayerPoint([point.lat, point.lon]);
+    const distance = layerPoint.distanceTo(target);
+    if (distance < minDist) {
+      minDist = distance;
+      closest = point;
+    }
+  });
+
+  if (minDist > 24) return null;
+  return closest;
+};
+
+const formatTooltip = (point) => {
+  const lines = [];
+  if (point.timestamp) lines.push(`<strong>${point.timestamp}</strong>`);
+  lines.push(`Altitude: ${formatAltitude(point.alt)}`);
+  lines.push(`Battery: ${formatSoc(point.batterySoc)}`);
+  lines.push(`Voltage: ${formatVoltage(point.batteryMv)}`);
+
+  if (point.homeLat != null && point.homeLon != null) {
+    const distance = haversineMeters(point.lat, point.lon, point.homeLat, point.homeLon);
+    const bearing = bearingDegrees(point.lat, point.lon, point.homeLat, point.homeLon);
+    lines.push(`Home: ${distance.toFixed(1)} m @ ${bearing.toFixed(0)}°`);
+  }
+
+  return lines.join("<br />");
+};
+
+const renderTrack = () => {
+  if (!points.length) return;
+  const latLngs = points.map((point) => [point.lat, point.lon]);
+
+  if (polyline) map.removeLayer(polyline);
+  polyline = L.polyline(latLngs, { color: "#5ad1ff", weight: 3 }).addTo(map);
+  map.fitBounds(polyline.getBounds(), { padding: [24, 24] });
+
+  if (!hoverMarker) {
+    hoverMarker = L.circleMarker(latLngs[0], {
+      radius: 5,
+      color: "#ffffff",
+      fillColor: "#5ad1ff",
+      fillOpacity: 0.9,
+      weight: 1,
+    }).addTo(map);
+  }
+};
+
+const parseTelemetry = (rows) => {
+  const parsed = rows
+    .map((row) => {
+      const lat = Number.isFinite(row[columnKeys.latDeg])
+        ? row[columnKeys.latDeg]
+        : toDegrees(row[columnKeys.latRad]);
+      const lon = Number.isFinite(row[columnKeys.lonDeg])
+        ? row[columnKeys.lonDeg]
+        : toDegrees(row[columnKeys.lonRad]);
+      if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+
+      const alt = Number.isFinite(row[columnKeys.alt])
+        ? row[columnKeys.alt]
+        : row[columnKeys.altHome];
+
+      const homeLat = Number.isFinite(row[columnKeys.homeLatDeg])
+        ? row[columnKeys.homeLatDeg]
+        : toDegrees(row[columnKeys.homeLatRad]);
+      const homeLon = Number.isFinite(row[columnKeys.homeLonDeg])
+        ? row[columnKeys.homeLonDeg]
+        : toDegrees(row[columnKeys.homeLonRad]);
+
+      return {
+        lat,
+        lon,
+        alt: Number.isFinite(alt) ? alt : null,
+        batterySoc: row[columnKeys.batterySoc],
+        batteryMv: row[columnKeys.batteryMv],
+        homeLat: Number.isFinite(homeLat) ? homeLat : null,
+        homeLon: Number.isFinite(homeLon) ? homeLon : null,
+        timestamp: row[columnKeys.timestamp],
+        timestampValue: row[columnKeys.timestamp] ? Date.parse(row[columnKeys.timestamp]) : null,
+      };
+    })
+    .filter(Boolean);
+
+  parsed.sort((a, b) => {
+    if (a.timestampValue == null || b.timestampValue == null) return 0;
+    return a.timestampValue - b.timestampValue;
+  });
+
+  return parsed;
+};
+
+fileInput.addEventListener("change", (event) => {
+  const file = event.target.files[0];
+  if (!file) return;
+
+  statusEl.textContent = "Parsing telemetry...";
+  statsEl.textContent = "";
+  exportButton.disabled = true;
+  resetButton.disabled = true;
+
+  Papa.parse(file, {
+    header: true,
+    skipEmptyLines: true,
+    dynamicTyping: true,
+    complete: (results) => {
+      points = parseTelemetry(results.data);
+
+      if (!points.length) {
+        statusEl.textContent = "No valid telemetry points found.";
+        return;
+      }
+
+      statusEl.textContent = `Loaded ${points.length} points.`;
+      exportButton.disabled = false;
+      resetButton.disabled = false;
+      renderTrack();
+
+      const first = points[0]?.timestamp ?? "—";
+      const last = points[points.length - 1]?.timestamp ?? "—";
+      updateSummary({ points: points.length, start: first, end: last });
+    },
+    error: () => {
+      statusEl.textContent = "Unable to parse file.";
+    },
+  });
+});
+
+map.on("mousemove", (event) => {
+  if (!points.length || !polyline) return;
+  const nearest = findNearestPoint(event.latlng);
+
+  if (!nearest) {
+    tooltip.hidden = true;
+    return;
+  }
+
+  tooltip.hidden = false;
+  tooltip.innerHTML = formatTooltip(nearest);
+  tooltip.style.left = `${event.containerPoint.x}px`;
+  tooltip.style.top = `${event.containerPoint.y}px`;
+
+  if (hoverMarker) {
+    hoverMarker.setLatLng([nearest.lat, nearest.lon]);
+  }
+});
+
+map.on("mouseout", () => {
+  tooltip.hidden = true;
+});
+
+exportButton.addEventListener("click", downloadKml);
+resetButton.addEventListener("click", () => {
+  fileInput.value = "";
+  resetState();
+});
+
+resetState();

--- a/tools/telemetry-parsing/index.html
+++ b/tools/telemetry-parsing/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SquirrelCast Telemetry Parser</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin=""
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div>
+        <h1>SquirrelCast Telemetry Parser</h1>
+        <p>
+          Upload a telemetry CSV to visualize the flight path, hover for stats, and
+          export KML for maps.
+        </p>
+      </div>
+    </header>
+
+    <main>
+      <section class="controls">
+        <label class="file-input">
+          <input type="file" id="csvFile" accept=".csv,text/csv" />
+          <span>Choose telemetry CSV</span>
+        </label>
+
+        <div class="buttons">
+          <button id="exportKml" disabled>Download KML</button>
+          <button id="reset" disabled>Reset</button>
+        </div>
+
+        <div class="status" id="status">No file loaded.</div>
+        <div class="stats" id="stats"></div>
+      </section>
+
+      <section class="map-wrapper">
+        <div id="map"></div>
+        <div class="tooltip" id="tooltip" hidden></div>
+      </section>
+    </main>
+
+    <script
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+      crossorigin=""
+    ></script>
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/tools/telemetry-parsing/styles.css
+++ b/tools/telemetry-parsing/styles.css
@@ -1,0 +1,154 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  --bg: #0e1014;
+  --panel: #171a21;
+  --accent: #5ad1ff;
+  --text: #f5f7ff;
+  --muted: #b4bdc6;
+  --border: rgba(255, 255, 255, 0.1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+header {
+  padding: 32px clamp(16px, 5vw, 48px);
+  background: linear-gradient(135deg, #17202b, #0e1014);
+  border-bottom: 1px solid var(--border);
+}
+
+header h1 {
+  margin: 0 0 8px;
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+}
+
+header p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 640px;
+}
+
+main {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: 24px;
+  padding: 24px clamp(16px, 5vw, 48px) 48px;
+}
+
+.controls {
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 20px;
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.file-input {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 999px;
+  background: rgba(90, 209, 255, 0.1);
+  border: 1px solid rgba(90, 209, 255, 0.35);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.file-input input {
+  display: none;
+}
+
+.buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+button {
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: var(--accent);
+  color: #001018;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+#reset {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+.status {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.stats {
+  font-size: 0.9rem;
+  color: var(--muted);
+  line-height: 1.5;
+  white-space: pre-line;
+}
+
+.map-wrapper {
+  position: relative;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  overflow: hidden;
+  min-height: 520px;
+}
+
+#map {
+  height: 100%;
+  min-height: 520px;
+}
+
+.tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: rgba(11, 13, 18, 0.9);
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text);
+  font-size: 0.85rem;
+  line-height: 1.4;
+  max-width: 240px;
+  transform: translate(12px, 12px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+}
+
+.tooltip strong {
+  display: block;
+  font-size: 0.9rem;
+  margin-bottom: 4px;
+}
+
+@media (max-width: 900px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  .map-wrapper,
+  #map {
+    min-height: 420px;
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a small, self-contained web tool to parse SquirrelCast telemetry CSVs so users can visualize flight tracks and export KML without additional tooling. 
- Ship the tool under `tools/telemetry-parsing` and replace the README's “coming soon” placeholder with a direct link to the tool.

### Description

- Added a static web UI at `tools/telemetry-parsing/index.html` which loads `leaflet` and `papaparse` and mounts the telemetry tool. 
- Implemented client-side parsing and visualization logic in `tools/telemetry-parsing/app.js` that supports latitude in degrees or radians, altitude fallbacks, battery values, home position, track rendering, hover tooltips, and KML export. 
- Added styling in `tools/telemetry-parsing/styles.css`, including a small fix to show multi-line stats (`white-space: pre-line`).
- Updated the main `Readme.md` to add a link to the new telemetry parsing tool under the "Additional Tools" section.

### Testing

- Served the repository with `python -m http.server 8000` and verified the new page loads in a browser, which succeeded. 
- Captured a screenshot of `http://localhost:8000/tools/telemetry-parsing/index.html` using a Playwright script and saved it as `artifacts/telemetry-parsing.png`, which completed successfully. 
- Performed local `git` operations (`git add`/`git commit`) to record the changes, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69835659010c83298ce1ac8fcd11814e)