### PR TITLE
Require GPS/homepoint for calculations; make map and controls height responsive; clamp hover tooltip

### DIFF
--- a/tools/telemetry-parsing/styles.css
+++ b/tools/telemetry-parsing/styles.css
@@ -41,6 +41,8 @@ main {
   grid-template-columns: minmax(260px, 320px) 1fr;
   gap: 24px;
   padding: 24px clamp(16px, 5vw, 48px) 48px;
+  min-height: calc(100vh - 220px);
+  align-items: stretch;
 }
 
 .controls {
@@ -51,6 +53,7 @@ main {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  min-height: clamp(420px, 70vh, 760px);
 }
 
 .file-input {
@@ -113,12 +116,12 @@ button[disabled] {
   border-radius: 16px;
   border: 1px solid var(--border);
   overflow: hidden;
-  min-height: 520px;
+  min-height: clamp(420px, 70vh, 760px);
 }
 
 #map {
   height: 100%;
-  min-height: 520px;
+  min-height: 0;
 }
 
 .tooltip {
@@ -132,7 +135,6 @@ button[disabled] {
   font-size: 0.85rem;
   line-height: 1.4;
   max-width: 240px;
-  transform: translate(12px, 12px);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
 }
 
@@ -149,6 +151,10 @@ button[disabled] {
 
   .map-wrapper,
   #map {
-    min-height: 420px;
+    min-height: clamp(360px, 60vh, 600px);
+  }
+
+  .controls {
+    min-height: clamp(360px, 60vh, 600px);
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent plotting and calculations from using invalid GPS data by ignoring telemetry rows where `flight.osd.gps_used` is not set. 
- Only calculate home distance and bearing when the flight `homepoint_set` is true to avoid incorrect home stats. 
- Fix hover tooltip being drawn outside the map and make the left panel/map respond to viewport height so the UI stays usable on various screen sizes.

### Description
- Add `columnKeys.gpsUsed` and `columnKeys.homepointSet` and skip rows in `parseTelemetry` when `gps_used` is not `true` or `1`, implemented in `tools/telemetry-parsing/app.js`.
- Only populate `homeLat`/`homeLon` when `homepointSet` is true and thread `homepointSet` into each parsed point; update `formatTooltip` to show home distance/bearing only when `homepointSet` is true.
- Clamp hover tooltip coordinates to the map container bounds (using `map.getContainer().getBoundingClientRect()` and padding) so the tooltip cannot be positioned out-of-frame, implemented in `map.on('mousemove', ...)` in `app.js`.
- Make layout responsive by setting min-height and clamp-based heights for `main`, `.controls`, `.map-wrapper` and `#map` in `tools/telemetry-parsing/styles.css`, and remove the fixed tooltip transform to simplify positioning.

### Testing
- Launched a local static server with `python -m http.server 8000` in `tools/telemetry-parsing` and captured a visual snapshot using a Playwright script (headless Chromium) at `artifacts/telemetry-parsing.png`, which completed successfully. 
- No unit tests were present or run for this change; runtime/visual smoke test above was used to validate layout and tooltip placement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69837406d2ec832986023c6c772afc87)